### PR TITLE
🧪 test: verify meta tags and stylesheet link

### DIFF
--- a/tests/homepage.spec.js
+++ b/tests/homepage.spec.js
@@ -7,6 +7,17 @@ test.describe('Homepage', () => {
     await page.goto(filePath);
   });
 
+  test('includes correct meta and link tags', async ({ page }) => {
+    const charsetMeta = page.locator('meta[charset="UTF-8"]');
+    await expect(charsetMeta).toHaveCount(1);
+
+    const viewportMeta = page.locator('meta[name="viewport"]');
+    await expect(viewportMeta).toHaveAttribute('content', 'width=device-width, initial-scale=1.0');
+
+    const stylesheetLink = page.locator('link[rel="stylesheet"]');
+    await expect(stylesheetLink).toHaveAttribute('href', 'style.css');
+  });
+
   test('loads and displays correct title', async ({ page }) => {
     await expect(page).toHaveTitle('Codex by ChatGPT');
   });


### PR DESCRIPTION
🎯 **What:** Added a missing test to verify the presence and attributes of meta tags and stylesheet link in `index.html`.
📊 **Coverage:** Now tests the charset, viewport meta tags, and the stylesheet link tag in the `<head>` of the page.
✨ **Result:** Improved test coverage and reliability for core HTML structure elements.

---
*PR created automatically by Jules for task [6976490947480538960](https://jules.google.com/task/6976490947480538960) started by @neilweitzel*