### PR TITLE
🧪 test: add test for Content-Security-Policy meta tag

### DIFF
--- a/tests/homepage.spec.js
+++ b/tests/homepage.spec.js
@@ -15,6 +15,9 @@ test.describe('Homepage', () => {
     const viewportMeta = page.locator('meta[name="viewport"]');
     await expect(viewportMeta).toHaveAttribute('content', 'width=device-width, initial-scale=1.0');
 
+    const cspMeta = page.locator('meta[http-equiv="Content-Security-Policy"]');
+    await expect(cspMeta).toHaveAttribute('content', "default-src 'self';");
+
     const stylesheetLink = page.locator('link[rel="stylesheet"]');
     await expect(stylesheetLink).toHaveAttribute('href', 'style.css');
   });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for `Content-Security-Policy` meta tag.
📊 **Coverage:** What scenarios are now tested: Added a test to check for the correct `Content-Security-Policy` meta tag content.
✨ **Result:** The improvement in test coverage: We now have automated verification that the correct CSP header is rendered on the HTML page via meta tag.

---
*PR created automatically by Jules for task [15204524291741717517](https://jules.google.com/task/15204524291741717517) started by @neilweitzel*