### PR TITLE
🧪 Add test for HTML lang attribute

### DIFF
--- a/tests/homepage.spec.js
+++ b/tests/homepage.spec.js
@@ -8,6 +8,11 @@ test.describe('Homepage', () => {
     await page.goto(filePath);
   });
 
+  test('has correct html lang attribute', async ({ page }) => {
+    const html = page.locator('html');
+    await expect(html).toHaveAttribute('lang', 'en');
+  });
+
   test('includes correct meta and link tags', async ({ page }) => {
     const charsetMeta = page.locator('meta[charset="UTF-8"]');
     await expect(charsetMeta).toHaveCount(1);


### PR DESCRIPTION
🎯 **What:** Added a missing test for the `lang` attribute on the HTML element in `index.html`.
📊 **Coverage:** The test suite now covers verifying that the `html` element has a `lang` attribute set to `en`.
✨ **Result:** Increased test coverage for basic HTML layout features, ensuring the application maintains accessibility standards and proper language metadata.

---
*PR created automatically by Jules for task [11219558005306938283](https://jules.google.com/task/11219558005306938283) started by @neilweitzel*