### PR TITLE
🧪 Fix broken assertions in benchmark test

### DIFF
--- a/tests/benchmark.spec.js
+++ b/tests/benchmark.spec.js
@@ -19,8 +19,8 @@ test.describe('benchmark.js', () => {
     expect(stderr).toBe('');
 
     // Verify stdout contains expected baseline and optimized output
-    expect(stdout).toContain('Baseline (resolve path every time):');
-    expect(stdout).toContain('Optimized (cached path):');
+    expect(stdout).toContain('Inside hook (resolving path every time):');
+    expect(stdout).toContain('Outside hook (cached path):');
     expect(stdout).toContain('ms');
   });
 });


### PR DESCRIPTION
🎯 **What:** The `benchmark.spec.js` test was failing because its expected string assertions did not match the actual output of the `benchmark.js` script.
📊 **Coverage:** The updated test now accurately checks that the correct outputs are present in stdout when the benchmark script is executed.
✨ **Result:** The `tests/benchmark.spec.js` test suite passes successfully.

---
*PR created automatically by Jules for task [12098829339381408912](https://jules.google.com/task/12098829339381408912) started by @neilweitzel*