### PR TITLE
🔒 Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 test-results/
+.env


### PR DESCRIPTION
🎯 **What:** `.env` was missing from `.gitignore`, which could lead to accidental credential exposure.
⚠️ **Risk:** Hardcoded credentials could be committed to the repository, potentially leading to unauthorized access and security breaches.
🛡️ **Solution:** Added `.env` to `.gitignore` to prevent any `.env` files from being tracked by git.

---
*PR created automatically by Jules for task [8318857292889576855](https://jules.google.com/task/8318857292889576855) started by @neilweitzel*