### PR TITLE
🧹 Refactor: Extract duplicated file path resolution in tests

### DIFF
--- a/tests/homepage.spec.js
+++ b/tests/homepage.spec.js
@@ -1,11 +1,9 @@
 const { test, expect } = require('@playwright/test');
-const path = require('path');
-
-const filePath = `file://${path.resolve(__dirname, '../index.html')}`;
+const { FILE_PATH } = require('./utils');
 
 test.describe('Homepage', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(filePath);
+    await page.goto(FILE_PATH);
   });
 
   test('has correct html lang attribute', async ({ page }) => {

--- a/tests/styles.spec.js
+++ b/tests/styles.spec.js
@@ -1,7 +1,5 @@
 const { test, expect } = require('@playwright/test');
-const path = require('path');
-
-const FILE_PATH = `file://${path.resolve(__dirname, '../index.html')}`;
+const { FILE_PATH } = require('./utils');
 
 test.describe('Computed Styles', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,5 @@
+const path = require('path');
+
+const FILE_PATH = `file://${path.resolve(__dirname, '../index.html')}`;
+
+module.exports = { FILE_PATH };


### PR DESCRIPTION
🎯 **What:** The duplicated file path resolution logic in `tests/styles.spec.js` and `tests/homepage.spec.js` has been extracted to a shared utility file `tests/utils.js`.
💡 **Why:** This improves maintainability and readability by keeping the codebase DRY. If the file path to `index.html` ever changes, it only needs to be updated in one place.
✅ **Verification:** Playwright tests were run using `npm run test` and all 14 tests pass successfully. Code review confirmed the changes are correct and safe.
✨ **Result:** The duplicated path resolution is removed, resulting in a cleaner and more maintainable test suite.

---
*PR created automatically by Jules for task [17932445102551684344](https://jules.google.com/task/17932445102551684344) started by @neilweitzel*