### PR TITLE
🧹 Remove unused variable in benchmark loop

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -15,7 +15,6 @@ console.log(`Inside hook (resolving path every time): ${(end - start).toFixed(2)
 start = performance.now();
 const filePath = `file://${path.resolve(__dirname, '../index.html')}`;
 for (let i = 0; i < iterations; i++) {
-  const p = filePath;
 }
 end = performance.now();
 console.log(`Outside hook (cached path): ${(end - start).toFixed(2)} ms for ${iterations} iterations`);


### PR DESCRIPTION
🎯 **What:** Removed the unused variable `p` in the outside hook loop in `benchmark.js`.
💡 **Why:** It removes unnecessary code, improving clarity and code health.
✅ **Verification:** Ran `node benchmark.js` to ensure the script functions properly. Verified using `npx playwright test` that no other tests were affected.
✨ **Result:** A cleaner benchmarking script without dead variables.

---
*PR created automatically by Jules for task [10495940901700307718](https://jules.google.com/task/10495940901700307718) started by @neilweitzel*