### PR TITLE
🧹 Fix duplicated file path resolution by extracting it to a shared utility

### DIFF
--- a/tests/homepage.spec.js
+++ b/tests/homepage.spec.js
@@ -1,11 +1,9 @@
 const { test, expect } = require('@playwright/test');
-const path = require('path');
-
-const filePath = `file://${path.resolve(__dirname, '../index.html')}`;
+const { INDEX_FILE_PATH } = require('./utils');
 
 test.describe('Homepage', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(filePath);
+    await page.goto(INDEX_FILE_PATH);
   });
 
   test('has correct html lang attribute', async ({ page }) => {

--- a/tests/styles.spec.js
+++ b/tests/styles.spec.js
@@ -1,11 +1,9 @@
 const { test, expect } = require('@playwright/test');
-const path = require('path');
-
-const FILE_PATH = `file://${path.resolve(__dirname, '../index.html')}`;
+const { INDEX_FILE_PATH } = require('./utils');
 
 test.describe('Computed Styles', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(FILE_PATH);
+    await page.goto(INDEX_FILE_PATH);
   });
 
   test('body has correct background and text color', async ({ page }) => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,3 @@
+const path = require('path');
+const INDEX_FILE_PATH = `file://${path.resolve(__dirname, '../index.html')}`;
+module.exports = { INDEX_FILE_PATH };


### PR DESCRIPTION
🎯 **What:** Extracted the duplicate file path resolution (`file://${path.resolve(__dirname, '../index.html')}`) from `tests/homepage.spec.js` and `tests/styles.spec.js` into a shared `tests/utils.js` file.
💡 **Why:** Reduces code duplication, improving maintainability by keeping the logic centralized.
✅ **Verification:** Ran `npx playwright test` to ensure all tests passed successfully with no regressions.
✨ **Result:** A cleaner and more maintainable testing setup.

---
*PR created automatically by Jules for task [5288964241795954960](https://jules.google.com/task/5288964241795954960) started by @neilweitzel*