### PR TITLE
🧹 Fix unused variable in benchmark loops

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -2,11 +2,12 @@ const path = require('path');
 
 const iterations = 10000;
 let start, end;
+let dummy;
 
 // Inside hook performance simulation
 start = performance.now();
 for (let i = 0; i < iterations; i++) {
-  const filePath = `file://${path.resolve(__dirname, '../index.html')}`;
+  dummy = `file://${path.resolve(__dirname, '../index.html')}`;
 }
 end = performance.now();
 console.log(`Inside hook (resolving path every time): ${(end - start).toFixed(2)} ms for ${iterations} iterations`);
@@ -15,7 +16,7 @@ console.log(`Inside hook (resolving path every time): ${(end - start).toFixed(2)
 start = performance.now();
 const filePath = `file://${path.resolve(__dirname, '../index.html')}`;
 for (let i = 0; i < iterations; i++) {
-  const p = filePath;
+  dummy = filePath;
 }
 end = performance.now();
 console.log(`Outside hook (cached path): ${(end - start).toFixed(2)} ms for ${iterations} iterations`);


### PR DESCRIPTION
🎯 **What:** Fixed unused variable warnings for `filePath` and `p` in `benchmark.js`.
💡 **Why:** Improved code health by removing dead assignments. Assigned the values to a `dummy` variable declared outside the loops to prevent JS engines from optimizing away the path resolution via dead code elimination, preserving the intent of the benchmark.
✅ **Verification:** Verified by executing `node benchmark.js` and running the Playwright test suite (`npm run test`), ensuring no functionality or behavior regressions.
✨ **Result:** Cleaned up code health issues inside `benchmark.js` while maintaining benchmark correctness.

---
*PR created automatically by Jules for task [5288585776835477261](https://jules.google.com/task/5288585776835477261) started by @neilweitzel*