### PR TITLE
perf(benchmark): add performance budget and fail on exceed

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -2,20 +2,38 @@ const path = require('path');
 
 const iterations = 10000;
 let start, end;
+let dummy1, dummy2; // Scoped outside to prevent dead code elimination
 
 // Inside hook performance simulation
 start = performance.now();
 const resolvedInsidePath = `file://${path.resolve(__dirname, '../index.html')}`;
 for (let i = 0; i < iterations; i++) {
   const filePath = resolvedInsidePath;
+  dummy1 = filePath;
 }
 end = performance.now();
-console.log(`Inside hook (resolving path every time): ${(end - start).toFixed(2)} ms for ${iterations} iterations`);
+const insideTime = end - start;
+console.log(`Inside hook (resolving path every time): ${insideTime.toFixed(2)} ms for ${iterations} iterations`);
 
 // Outside hook performance simulation
 start = performance.now();
 const filePath = `file://${path.resolve(__dirname, '../index.html')}`;
 for (let i = 0; i < iterations; i++) {
+  dummy2 = filePath;
 }
 end = performance.now();
-console.log(`Outside hook (cached path): ${(end - start).toFixed(2)} ms for ${iterations} iterations`);
+const outsideTime = end - start;
+console.log(`Outside hook (cached path): ${outsideTime.toFixed(2)} ms for ${iterations} iterations`);
+
+// Performance budget check
+// A budget of 50ms is chosen to provide a generous buffer for slower CI environments
+// while remaining strict enough to catch major regressions like unintended synchronous I/O.
+// Under typical conditions, these operations take < 5ms.
+const BUDGET_MS = 50;
+
+if (insideTime > BUDGET_MS || outsideTime > BUDGET_MS) {
+  console.error(`Error: Performance budget exceeded! Limit is ${BUDGET_MS}ms.`);
+  process.exit(1);
+} else {
+  console.log(`Performance is within the ${BUDGET_MS}ms budget.`);
+}


### PR DESCRIPTION
This PR modifies `benchmark.js` to enforce a performance budget.
It introduces dummy variables scoped outside the benchmark loops to prevent dead code elimination, and checks if execution time exceeds 50ms.
If it exceeds 50ms, the script now exits with code 1, which fails CI runs.
50ms was chosen as a generous threshold that catches significant regressions like accidental synchronous I/O while preventing flakes on slower CI runners.

---
*PR created automatically by Jules for task [1066245145519027550](https://jules.google.com/task/1066245145519027550) started by @neilweitzel*