### PR TITLE
Fix dependency hygiene: Add playwright artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 test-results/
 .env
+playwright-report/
+blob-report/


### PR DESCRIPTION
Adding these playwright test artifact directories to `.gitignore` improves dependency hygiene by preventing accidental commits of test outputs.

---
*PR created automatically by Jules for task [7255607516785868113](https://jules.google.com/task/7255607516785868113) started by @neilweitzel*