### PR TITLE
docs: update README with explicit run examples and screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # Apex
 
+## Screenshots
+![Homepage](tests/styles.spec.js-snapshots/homepage-linux.png)
+![Charts](tests/charts.spec.js-snapshots/charts-section-linux.png)
+
 ## About Apex
 Apex is a client-side karting telemetry and leaderboard app. It supports parsing telemetry data, local CSV upload handling, robust data validation, and displaying dynamic leaderboard and charts.
 
 ## How to Run
-Since there is no build step, you can run the app by serving the root directory using any local web server (e.g., `npx serve .` or `python3 -m http.server`) and opening `index.html`.
+Since there is no build step, you can run the app by serving the `src` directory using any local web server and opening `index.html` in your browser.
+
+Example using `serve`:
+```bash
+npx serve src
+```
+
+Example using Python's `http.server`:
+```bash
+python3 -m http.server -d src
+```
 
 ## Testing
 To run tests, install dependencies and use Playwright:


### PR DESCRIPTION
docs: add run examples and screenshots to README.md

Added explicit bash commands for serving the src directory using `npx serve` and Python's `http.server`. Also added a Screenshots section linking to existing Playwright visual regression snapshots.

---
*PR created automatically by Jules for task [2174226759533700795](https://jules.google.com/task/2174226759533700795) started by @neilweitzel*