### PR TITLE
fix(ci): make the Pages deploy work and gate it on the tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  # Allows a redeploy of the current main without pushing a commit.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -15,7 +17,40 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Never publish a build that does not pass its own tests.
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Validate telemetry data
+        # --if-present so this stays green on revisions that predate the script.
+        run: npm run validate:data --if-present
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npm test
+      - name: Upload HTML report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-deploy
+          path: playwright-report/
+          retention-days: 30
+
   deploy:
+    needs: verify
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -25,9 +60,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          # Enable Pages on first run instead of failing with
+          # "Get Pages site failed", which is what happened before Pages was
+          # switched to the GitHub Actions source by hand.
+          enablement: true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
+          # The app is served straight from src/; there is no build step.
           path: './src'
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ export into the browser and it parses the data, ranks the drivers, charts their
 laps, and draws the track from GPS telemetry — with no server, no build step,
 and no data leaving the machine.
 
+**[Open the live app](https://neilweitzel.github.io/Apex-Race-Telemetry/)** — then
+upload one of the demo files from `dataset/` to populate it.
+
 ## Features
 
 - **Local CSV Upload:** Process telemetry data entirely on the client.
@@ -157,6 +160,14 @@ after a UI change with:
 ```bash
 npm run screenshots
 ```
+
+## Deployment
+
+Pushing to `main` publishes `src/` to GitHub Pages through
+`.github/workflows/deploy.yml`, which serves the live app linked above. The
+workflow validates the telemetry data and runs the full test suite before
+publishing, so a failing build never reaches the site, and it can be run from the
+Actions tab to redeploy the current `main` without a new commit.
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/neilweitzel/ChatGPT-test.git"
+    "url": "git+https://github.com/neilweitzel/Apex-Race-Telemetry.git"
   },
   "keywords": [
     "karting",
@@ -23,9 +23,9 @@
   "license": "ISC",
   "type": "module",
   "bugs": {
-    "url": "https://github.com/neilweitzel/ChatGPT-test/issues"
+    "url": "https://github.com/neilweitzel/Apex-Race-Telemetry/issues"
   },
-  "homepage": "https://github.com/neilweitzel/ChatGPT-test#readme",
+  "homepage": "https://neilweitzel.github.io/Apex-Race-Telemetry/",
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "serve": "^14.2.6"


### PR DESCRIPTION
## The failure

Every push to `main` failed the **Deploy** job with:

```
Get Pages site failed. Please verify that the repository has Pages enabled
and configured to build using GitHub Actions
HttpError: Not Found
```

Two causes, not one:

1. The repository had never had Pages switched to the **GitHub Actions** source, so there was no Pages site to deploy to.
2. `actions/configure-pages` was running with `enablement: false`, so it could not create the site either — it just failed.

## Fixed

- **Pages is enabled** for the repository with GitHub Actions as the source. The site is live at [neilweitzel.github.io/Apex-Race-Telemetry](https://neilweitzel.github.io/Apex-Race-Telemetry/), and the previously failing run now succeeds.
- `configure-pages` runs with **`enablement: true`**, so a fork or a recreated repository provisions Pages on the first run rather than failing the same way.
- **Deployment is gated on tests.** A `verify` job installs, validates the telemetry data and runs the Playwright suite, and `deploy` now `needs: verify`. Previously any push to `main` published straight to the live site regardless of whether the suite passed — a red build would have shipped.
- Added **`workflow_dispatch`**, so `main` can be redeployed without pushing an empty commit.
- `package.json` still referenced the pre-rename `ChatGPT-test` URLs; `repository` and `bugs` now point at `Apex-Race-Telemetry`, and `homepage` at the live site.

The data-validation step uses `npm run validate:data --if-present` so it stays green on revisions that predate that script (it arrives in #49).

## Verified against the live deployment

Not just "the workflow went green" — I drove the deployed site:

| Check | Result |
| --- | --- |
| `/`, `styles/style.css`, `ui/upload.js`, `lib/detect.js` | all HTTP 200 |
| Page load | no console errors, no failed requests |
| Feature list | 7 items |
| Lap CSV upload | leaderboard renders 6 driver rows, status "Loaded 86 laps" |
| GPX upload | "Track Map (3 laps detected)", replay controls present |
| Ghost replay | plays and reports a live delta (-0.139s) |
| Coexistence | leaderboard still present after the GPS upload |

Relative asset paths work correctly under the `/Apex-Race-Telemetry/` subpath, so no base-href change is needed.